### PR TITLE
feat: Add highlights for dashboard-nvim

### DIFF
--- a/lua/cyberdream/theme.lua
+++ b/lua/cyberdream/theme.lua
@@ -176,6 +176,23 @@ function M.setup()
         AlphaFooter = { fg = t.cyan },
         AlphaButtons = { fg = t.blue },
 
+        -- dashboard-nvim
+        DashboardHeader = { fg = t.purple },
+        DashboardFooter = { fg = t.cyan },
+        -- dashboard-nvim: doom theme
+        DashboardShortCut = { fg = t.orange },
+        DashboardDesc = { fg = t.orange },
+        DashboardKey = { fg = t.green },
+        DashboardIcon = { fg = t.blue },
+        -- dashboard-nvim: hyper theme
+        DashboardProjectTitle = { fg = t.blue },
+        DashboardProjectTitleIcon = { fg = t.orange },
+        DashboardProjectIcon = { fg = t.orange },
+        DashboardMruTitle = { fg = t.blue },
+        DashboardMruIcon = { fg = t.orange },
+        DashboardFiles = { fg = t.cyan },
+        DashboardShortCutIcon = { fg = t.pink },
+
         -- Telescope
         TelescopeBorder = { fg = t.bgHighlight },
         TelescopePromptTitle = { fg = t.blue },


### PR DESCRIPTION
LazyVim switched from Alpha to Dashboard a few months back. This brings highlight colours from the theme to the Dashboard plugin.

I only checked it against the "doom" theme but it should be mostly fine for the "hyper" theme as well. For the doom theme, in LazyVim, it looks like this:

![Screenshot 2023-12-30 at 10 42 20 AM](https://github.com/scottmckendry/cyberdream.nvim/assets/291808/9548ea42-0e36-46a7-a49f-4b31ce79476c)