### PR TITLE
fix: change wezterm cursor_fg

### DIFF
--- a/extras/wezterm.lua
+++ b/extras/wezterm.lua
@@ -15,4 +15,9 @@ return {
     ansi = { "#16181a", "#ff6e5e", "#5eff6c", "#f1ff5e", "#5ea1ff", "#bd5eff", "#5ef1ff", "#ffffff" },
     brights = { "#3c4048", "#ff6e5e", "#5eff6c", "#f1ff5e", "#5ea1ff", "#bd5eff", "#5ef1ff", "#ffffff" },
     indexed = { [16] = "#ffbd5e", [17] = "#ff6e5e" },
+
+    -- tab_bar = {
+    --   -- Make the tab ar transparent
+    --   background = "rgb(22, 24, 26 / 20%)",
+    -- },
 }

--- a/extras/wezterm.lua
+++ b/extras/wezterm.lua
@@ -15,9 +15,4 @@ return {
     ansi = { "#16181a", "#ff6e5e", "#5eff6c", "#f1ff5e", "#5ea1ff", "#bd5eff", "#5ef1ff", "#ffffff" },
     brights = { "#3c4048", "#ff6e5e", "#5eff6c", "#f1ff5e", "#5ea1ff", "#bd5eff", "#5ef1ff", "#ffffff" },
     indexed = { [16] = "#ffbd5e", [17] = "#ff6e5e" },
-
-    -- tab_bar = {
-    --   -- Make the tab ar transparent
-    --   background = "rgb(22, 24, 26 / 20%)",
-    -- },
 }

--- a/extras/wezterm.lua
+++ b/extras/wezterm.lua
@@ -3,7 +3,7 @@ return {
     background = "#16181a",
 
     cursor_bg = "#ffffff",
-    cursor_fg = "#ffffff",
+    cursor_fg = "#000000",
     cursor_border = "#ffffff",
 
     selection_fg = "#ffffff",


### PR DESCRIPTION
<img width="117" alt="Screenshot 2024-04-28 at 1 52 02 AM" src="https://github.com/scottmckendry/cyberdream.nvim/assets/53562817/21c2e9e4-89d5-4896-9faa-3c66e4d8c0ec">

Can't see the text because `cursor_fg` and `cursor_bg` is the same, so I change `	cursor_fg = "#000000"`

I can change it to another color if you think bester 