### PR TITLE
Port Cyberdream to Helix editor

### DIFF
--- a/extras/helix/README.md
+++ b/extras/helix/README.md
@@ -1,0 +1,10 @@
+## Usage
+
+### Install
+
+1. Place the `cyberdream.toml` under `$HOME/.config/helix/themes`
+2. Open `hx` and run the command `:theme cyberdream`
+3. If you want permanentely to use the theme, add this to your `$HOME/.config/helix/config.toml`:
+```toml
+theme = "cyberdream"
+```

--- a/extras/helix/cyberdream.toml
+++ b/extras/helix/cyberdream.toml
@@ -1,0 +1,87 @@
+"ui.background" = "bg"
+"ui.text" = "fg"
+"ui.cursor" = "fg"
+"ui.cursor.primary" = "blue"
+"ui.linenr" = "grey"
+"ui.statusline" = { fg = "blue", bg = "bg" }
+"ui.selection" = "green"
+"ui.selection.primary" = "magenta"
+
+# Syntax Highlighting for Code
+"comment" = { fg = "grey", modifiers = ["italic"] }
+"comment.line" = { fg = "grey", modifiers = ["italic"] }
+"comment.block" = { fg = "grey", modifiers = ["italic"] }
+"comment.documentation" = { fg = "blue", modifiers = ["italic"] }
+"keyword" = "orange"
+"keyword.control" = "orange"
+"keyword.operator" = "pink"
+"keyword.function" = "orange"
+"type" = "cyan"
+"type.builtin" = "cyan"
+"function" = "blue"
+"function.builtin" = "pink"
+"function.method" = { fg = "cyan", underline = { color = "blue", style = "line"} }
+"variable" = "fg"
+"variable.builtin" = "magenta"
+"variable.parameter" = "cyan"
+"string" = "green"
+"string.special" = "pink"
+"constant" = "yellow"
+"constant.builtin" = "red"
+"constant.numeric" = "yellow"
+"constant.character" = "pink"
+"constant.boolean" = "red"
+"attribute" = "magenta"
+"operator" = "pink"
+"tag" = { fg = "purple", modifiers = ["bold"] }
+"tag.special" = { fg = "orange", modifiers = ["bold"] }
+"namespace" = "cyan"
+"macro" = "orange"
+"label" = "red"
+
+# Interface specific
+"ui.cursorline.primary" = { bg = "bgHighlight" }
+"ui.cursorline.secondary" = { bg = "bgAlt" }
+"ui.cursorcolumn.primary" = { bg = "bgHighlight" }
+"ui.cursorcolumn.secondary" = { bg = "bgAlt" }
+"ui.statusline.normal" = { fg = "fg", bg = "bg" }
+"ui.statusline.insert" = { fg = "green", bg = "bg" }
+"ui.statusline.select" = { fg = "blue", bg = "bg" }
+"ui.statusline.command" = { fg = "red", bg = "bg" }
+"ui.statusline.visual" = { fg = "purple", bg = "bg" }
+
+# Diagnostic styles
+"warning" = { fg = "yellow", modifiers = ["bold"] }
+"error" = { fg = "red", modifiers = ["bold"] }
+"info" = { fg = "cyan", modifiers = ["bold"] }
+"hint" = { fg = "blue", modifiers = ["bold"] }
+"diagnostic.error" = { fg = "red" }
+"diagnostic.warning" = { fg = "yellow" }
+"diagnostic.info" = { fg = "cyan" }
+"diagnostic.hint" = { fg = "blue" }
+
+# Popups and Menus
+"ui.popup" = { fg = "fg", bg = "bg" }
+"ui.popup.info" = { fg = "cyan", bg = "bgAlt" }
+"ui.menu" = { fg = "fg", bg = "bg" }
+"ui.menu.selected" = { fg = "bg", bg = "fg" }
+
+# Additional overrides
+"ui.virtual.whitespace" = "grey"
+"ui.virtual.indent-guide" = { fg = "grey", style = "dotted" }
+
+[palette]
+bg = "#16181a"
+fg = "#ffffff"
+grey = "#7b8496"
+blue = "#5ea1ff"
+green = "#5eff6c"
+cyan = "#5ef1ff"
+red = "#ff6e5e"
+yellow = "#f1ff5e"
+magenta = "#ff5ef1"
+pink = "#ff5ea0"
+orange = "#ffbd5e"
+purple = "#bd5eff"
+bgAlt = "#1e2124"
+bgHighlight = "#3c4048"

--- a/extras/helix/cyberdream.toml
+++ b/extras/helix/cyberdream.toml
@@ -1,9 +1,8 @@
 "ui.background" = "bg"
 "ui.text" = "fg"
-"ui.cursor" = "fg"
-"ui.cursor.primary" = "blue"
+"ui.cursor" = { bg = "fg", fg = "bg" }
 "ui.linenr" = "grey"
-"ui.statusline" = { fg = "blue", bg = "bg" }
+"ui.statusline" = { fg = "cyan" }
 "ui.selection" = "green"
 "ui.selection.primary" = "magenta"
 
@@ -20,22 +19,22 @@
 "type.builtin" = "cyan"
 "function" = "blue"
 "function.builtin" = "pink"
-"function.method" = { fg = "cyan", underline = { color = "blue", style = "line"} }
+"function.method" = "blue"
 "variable" = "fg"
 "variable.builtin" = "magenta"
 "variable.parameter" = "cyan"
 "string" = "green"
 "string.special" = "pink"
-"constant" = "yellow"
+"constant" = "fg"
 "constant.builtin" = "red"
 "constant.numeric" = "yellow"
 "constant.character" = "pink"
 "constant.boolean" = "red"
 "attribute" = "magenta"
-"operator" = "pink"
+"operator" = "purple"
 "tag" = { fg = "purple", modifiers = ["bold"] }
 "tag.special" = { fg = "orange", modifiers = ["bold"] }
-"namespace" = "cyan"
+"namespace" = "purple"
 "macro" = "orange"
 "label" = "red"
 


### PR DESCRIPTION
[helix](https://github.com/helix-editor/helix) is one of more recent modal editors, based on kakoune. It has builtin support to treesitter and LSP.

I tried to port it but i think the theme config needs some improvements as it isn't complete match with the original. What do you think? Could anyone help me?

<img width="590" alt="image" src="https://github.com/scottmckendry/cyberdream.nvim/assets/44469426/81c7b3db-d42f-4ce5-af20-fd5d9ae0cd12">

<img width="590" alt="image" src="https://github.com/scottmckendry/cyberdream.nvim/assets/44469426/87f6dc13-7f9b-401e-acf0-e599c98e66d6">

the complete theme creation documentation of helix can be found here: https://docs.helix-editor.com/themes.html