### PR TITLE
docs: add missing comma in readme config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ require("cyberdream").setup({
     hide_fillchars = false,
 
     -- Modern borderless telescope theme
-    borderless_telescope = true
+    borderless_telescope = true,
 
     -- Set terminal colors used in `:terminal`
-    terminal_colors = true
+    terminal_colors = true,
 
     theme = {
         variant = "default", -- use "light" for the light variant


### PR DESCRIPTION
well, just some missing commas in the README's config. I figured even I could fix that.