### PR TITLE
feat: add override function

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ require("cyberdream").setup({
             -- Complete list can be found in `lua/cyberdream/theme.lua`
         },
 
+        -- Override a highlight group entirely using the color palette
+        overrides = function(colors) -- NOTE: This function nullifies the `highlights` option
+            -- Example:
+            return {
+                Comment = { fg = colors.green, bg = "NONE", italic = true },
+                ["@property"] = { fg = colors.magenta, bold = true },
+            }
+        end,
+
         -- Override a color entirely
         colors = {
             -- For a list of colors see `lua/cyberdream/colours.lua`

--- a/lua/cyberdream/colors.lua
+++ b/lua/cyberdream/colors.lua
@@ -1,10 +1,48 @@
+---@class CyberdreamColors
 local M = {}
 
+---@class CyberdreamColorLight
+---@field bg "#ffffff"|string
+---@field bgAlt "#f7f8f9"|string
+---@field bgHighlight "#e9eef2"|string
+---@field fg "#16181a"|string
+---@field lightGrey "#bbd3ff"|string
+---@field grey "#7b8496"|string
+---@field blue "#5ea1ff"|string
+---@field green "#5eff6c"|string
+---@field cyan "#5ef1ff"|string
+---@field red "#ff6e5e"|string
+---@field yellow "#f1ff5e"|string
+---@field magenta "#ff5ef1"|string
+---@field pink "#ff5ea0"|string
+---@field orange "#ffbd5e"|string
+---@field purple "#bd5eff"|string
+
+---@class CyberdreamColorDefault
+---@field bg "#16181a"|string
+---@field bgAlt "#1e2124"|string
+---@field bgHighlight "#3c4048"|string
+---@field fg "#ffffff"|string
+---@field lightGrey "#bbd3ff"|string
+---@field grey "#7b8496"|string
+---@field blue "#5ea1ff"|string
+---@field green "#5eff6c"|string
+---@field cyan "#5ef1ff"|string
+---@field red "#ff6e5e"|string
+---@field yellow "#f1ff5e"|string
+---@field magenta "#ff5ef1"|string
+---@field pink "#ff5ea0"|string
+---@field orange "#ffbd5e"|string
+---@field purple "#bd5eff"|string
+
+---@class CyberdreamColors
+---@field default CyberdreamColorDefault
 M.default = {
     bg = "#16181a",
     bgAlt = "#1e2124",
     bgHighlight = "#3c4048",
     fg = "#ffffff",
+    lightGrey = "#bbd3ff",
     grey = "#7b8496",
     blue = "#5ea1ff",
     green = "#5eff6c",
@@ -17,7 +55,8 @@ M.default = {
     purple = "#bd5eff",
 }
 
--- Light theme
+---@class CyberdreamColors
+---@field light CyberdreamColorLight
 M.light = {
     bg = "#ffffff",
     bgAlt = "#eaeaea",

--- a/lua/cyberdream/config.lua
+++ b/lua/cyberdream/config.lua
@@ -9,11 +9,14 @@ local M = {}
 ---@field underline boolean
 ---@field strikethrough boolean
 
----@alias CyberdreamOverrideFn fun(palette: CyberdreamColorDefault|CyberdreamColorLight): CyberdreamHighlight
+---@alias Colors table<CyberdreamColorDefault|CyberdreamColorLight|string, string>
+---@alias CyberdreamPalette CyberdreamColorLight|CyberdreamColorDefault|Colors
+
+---@alias CyberdreamOverrideFn fun(palette: CyberdreamPalette): CyberdreamHighlight
 
 ---@class ThemeConfig
 ---@field variant? string | "'default'" | "'light'" | "'auto'"
----@field colors? table<string, string>
+---@field colors? CyberdreamPalette
 ---@field highlights? table<string, table<string, string>>
 ---@field overrides? CyberdreamOverrideFn
 

--- a/lua/cyberdream/config.lua
+++ b/lua/cyberdream/config.lua
@@ -1,9 +1,21 @@
 local M = {}
 
+---@class CyberdreamHighlight
+---@field fg string
+---@field bg string
+---@field sp string
+---@field bold boolean
+---@field italic boolean
+---@field underline boolean
+---@field strikethrough boolean
+
+---@alias CyberdreamOverrideFn fun(palette: CyberdreamColorDefault|CyberdreamColorLight): CyberdreamHighlight
+
 ---@class ThemeConfig
 ---@field variant? string | "'default'" | "'light'" | "'auto'"
 ---@field colors? table<string, string>
 ---@field highlights? table<string, table<string, string>>
+---@field overrides? CyberdreamOverrideFn
 
 ---@class Config
 ---@field transparent? boolean

--- a/lua/cyberdream/theme.lua
+++ b/lua/cyberdream/theme.lua
@@ -7,6 +7,7 @@ function M.setup()
     local opts = config.options
 
     local theme = {}
+    ---@type CyberdreamColorDefault|CyberdreamColorLight
     local t = colors.default
     if opts.theme.variant == "light" then
         t = colors.light
@@ -383,8 +384,12 @@ function M.setup()
         theme.highlights.NotifyBackground = { bg = "#000000" }
     end
 
+    local overrides = opts.theme.overrides or opts.theme.highlights
+    if type(overrides) == "function" then
+        overrides = overrides(t)
+    end
     -- Override highlights with user defined highlights
-    theme.highlights = vim.tbl_deep_extend("force", theme.highlights, opts.theme.highlights or {})
+    theme.highlights = vim.tbl_deep_extend("force", theme.highlights, overrides or {})
 
     return theme
 end

--- a/lua/cyberdream/theme.lua
+++ b/lua/cyberdream/theme.lua
@@ -7,19 +7,22 @@ function M.setup()
     local opts = config.options
 
     local theme = {}
-    ---@type CyberdreamColorDefault|CyberdreamColorLight
+    ---@type CyberdreamPalette
     local t = colors.default
     if opts.theme.variant == "light" then
+        ---@type CyberdreamPalette
         t = colors.light
     end
 
     if opts.theme.variant == "auto" then
         if vim.o.background == "light" then
+            ---@type CyberdreamPalette
             t = colors.light
         end
     end
 
     -- Override colors with user defined colors
+    ---@type CyberdreamPalette
     t = vim.tbl_deep_extend("force", t, opts.theme.colors)
 
     if opts.transparent then

--- a/lua/lualine/themes/cyberdream.lua
+++ b/lua/lualine/themes/cyberdream.lua
@@ -1,3 +1,4 @@
+---@type CyberdreamPalette
 local colors = require("cyberdream.colors").default
 local opts = require("cyberdream.config").options
 


### PR DESCRIPTION
I explained all better in #69 with more examples.

This feature will introduce the ability to override highlight groups using the theme's palette or hard coding it as it's done in `theme.highlights`.

This feature also let's the users and the developers see the available colours in the palette and their corresponding values.

<img width="558" alt="Autocompletion" src="https://github.com/scottmckendry/cyberdream.nvim/assets/71392160/74a4bcb5-03b9-4ced-ab6b-71c3988049d9">

> [!NOTE]
>
> This screenshot was taken from inside `require("cyberdream").setup`

Closes #69