### PR TITLE
feat: improve DX

### DIFF
--- a/.codespellignorewords
+++ b/.codespellignorewords
@@ -1,0 +1,2 @@
+noice
+Noice

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
             - uses: actions/checkout@v4
 
             - name: Run selene
-              uses: NTBBloodbath/selene-action@v1.0.0
+              uses: AlejandroSuero/selene-linter-action@67f24332d5c38f523c8f78dc02657b2141dadbdf
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   args: --display-style quiet lua

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,22 +23,22 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - name: Run selene
-              uses: AlejandroSuero/selene-linter-action@67f24332d5c38f523c8f78dc02657b2141dadbdf
-              with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
-                  args: --display-style quiet lua
+            - name: Install Selene
+              run: cargo install selene
+
+            - name: Run Selene
+              run: selene --display-style quiet --config ./selene.toml lua
 
     codespell:
         runs-on: ubuntu-latest
         steps:
-          - uses: actions/checkout@v4
+            - uses: actions/checkout@v4
 
-          - name: Install codespell
-            run: pip install codespell
+            - name: Install codespell
+              run: pip install codespell
 
-          - name: Use codespell
-            run: make spell
+            - name: Use codespell
+              run: make spell
 
     generate-extras:
         runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,28 @@ jobs:
                   version: latest
                   args: --color always --check .
 
+    selene:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Run selene
+              uses: NTBBloodbath/selene-action@v1.0.0
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  args: --display-style quiet lua
+
+    codespell:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v4
+
+          - name: Install codespell
+            run: pip install codespell
+
+          - name: Use codespell
+            run: make spell
+
     generate-extras:
         runs-on: ubuntu-latest
         steps:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+GREEN="\033[00;32m"
+RESTORE="\033[0m"
+
+# make the output of the message appear green
+define style_calls
+	$(eval $@_msg = $(1))
+	echo ${GREEN}${$@_msg}${RESTORE}
+endef
+
+lint: style-lint
+	@$(call style_calls,"Running selene")
+	@selene --display-style quiet --config ./selene.toml lua
+	@$(call style_calls,"Done!")
+
+.PHONY: lint
+
+style-lint:
+	@$(call style_calls,"Running stylua check")
+	@stylua --color always -f ./.stylua.toml --check lua
+	@$(call style_calls,"Done!")
+
+.PHONY: style-lint
+
+format:
+	@$(call style_calls,"Running stylua format")
+	@stylua --color always -f ./.stylua.toml lua
+	@$(call style_calls,"Done!")
+
+.PHONY: format
+
+spell:
+	@$(call style_calls,"Running codespell check")
+	@codespell --quiet-level=2 --check-hidden --skip=./.git,./CHANGELOG.md --ignore-words=./.codespellignorewords .
+	@$(call style_calls,"Done!")
+
+.PHONY: spell
+
+spell-write:
+	@$(call style_calls,"Running codespell write")
+	@codespell --quiet-level=2 --check-hidden --skip=./.git,./CHANGELOG.md --write-changes --ignore-words=./.codespellignorewords .
+	@$(call style_calls,"Done!")
+
+.PHONY: spell-write

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
-GREEN="\033[00;32m"
-RESTORE="\033[0m"
+ifeq ($(OS),Windows_NT)
+	GREEN=[00;32m
+	RESTORE=[0m
+else
+	GREEN="\033[0;32m"
+	RESTORE="\033[0m"
+endif
 
 # make the output of the message appear green
 define style_calls

--- a/extras/helix/README.md
+++ b/extras/helix/README.md
@@ -4,7 +4,7 @@
 
 1. Place the `cyberdream.toml` under `$HOME/.config/helix/themes`
 2. Open `hx` and run the command `:theme cyberdream`
-3. If you want permanentely to use the theme, add this to your `$HOME/.config/helix/config.toml`:
+3. If you want permanently to use the theme, add this to your `$HOME/.config/helix/config.toml`:
 ```toml
 theme = "cyberdream"
 ```

--- a/neovim.yml
+++ b/neovim.yml
@@ -1,0 +1,27 @@
+---
+base: lua51
+
+globals:
+  jit:
+    any: true
+  vim:
+    any: true
+  assert:
+    args:
+      - type: bool
+      - type: string
+        required: false
+  after_each:
+    args:
+      - type: function
+  before_each:
+    args:
+      - type: function
+  describe:
+    args:
+      - type: string
+      - type: function
+  it:
+    args:
+      - type: string
+      - type: function

--- a/selene.toml
+++ b/selene.toml
@@ -1,0 +1,9 @@
+std="neovim"
+
+[rules]
+global_usage = "warn"
+multiple_statements = "allow"
+incorrect_standard_library_use = "allow"
+mixed_table = "allow"
+unused_variable = "warn"
+unescoped_variables = "warn"


### PR DESCRIPTION
Improving the developer experience of checking for formatting, linting and spelling errors.

Added [selene](https://github.com/Kampfkarren/selene) and [codespell](https://github.com/codespell-project/codespell) both locally with `make lint` and `make spell`, and in CI with an action for each of them.

---

It could be nice to include [commitlint](https://commitlint.js.org/) for maintaining a [conventional commit](https://www.conventionalcommits.org/) log.