### PR TITLE
feat(#69): modified and added `hl_groups`

### DIFF
--- a/lua/cyberdream/theme.lua
+++ b/lua/cyberdream/theme.lua
@@ -112,14 +112,14 @@ function M.setup()
         Constant = { fg = t.pink },
         String = { fg = t.green },
         Character = { fg = t.green },
-        Boolean = { fg = t.orange },
+        Boolean = { fg = t.cyan },
         Number = { fg = t.orange },
 
         Identifier = { fg = t.fg },
         Function = { fg = t.blue },
         Statement = { fg = t.magenta },
         Operator = { fg = t.purple },
-        Keyword = { fg = t.yellow },
+        Keyword = { fg = t.orange },
         PreProc = { fg = t.cyan },
 
         Type = { fg = t.purple },

--- a/lua/cyberdream/theme.lua
+++ b/lua/cyberdream/theme.lua
@@ -109,15 +109,17 @@ function M.setup()
         Whitespace = { fg = t.grey },
         WildMenu = { fg = t.bg, bg = t.blue },
 
-        Constant = { fg = t.fg },
+        Constant = { fg = t.pink },
         String = { fg = t.green },
         Character = { fg = t.green },
+        Boolean = { fg = t.orange },
+        Number = { fg = t.orange },
 
         Identifier = { fg = t.fg },
         Function = { fg = t.blue },
         Statement = { fg = t.magenta },
         Operator = { fg = t.purple },
-        Keyword = { fg = t.orange },
+        Keyword = { fg = t.yellow },
         PreProc = { fg = t.cyan },
 
         Type = { fg = t.purple },
@@ -334,6 +336,9 @@ function M.setup()
         ["@variable"] = { fg = t.fg },
         ["@markup.strong"] = { fg = t.pink, bold = true },
         ["@markup.italic"] = { fg = t.blue, italic = true },
+        ["@boolean"] = { link = "Boolean" },
+        ["@number"] = { link = "Number" },
+        ["@keyword"] = { link = "Keyword" },
     }
 
     if opts.borderless_telescope then


### PR DESCRIPTION
@scottmckendry in the PR I made the changes mentioned in #69 with the addition of `Constant` from `fg = t.fg` -> `fg = t.pink`.

> [!WARNING]
> Flashbang ahead! 🫡
>
> In the video I use the `toggle` between dark and light mode.

https://github.com/scottmckendry/cyberdream.nvim/assets/71392160/edcebcc7-4dbe-4379-be29-2083feab4b4a

After the changes:

<img width="756" alt="Screenshot 2024-06-14 at 22 31 05" src="https://github.com/scottmckendry/cyberdream.nvim/assets/71392160/52a8f75f-709f-462e-a092-fbdc42631be3">

> [!NOTE]
>
> The changes in color in `---@module ...` is because of [paint.nvim](https://github.com/folke/paint.nvim) which let's me link a matching string to a highlight group, in this case I have it link to `Constant` apparently.