### PR TITLE
feat(telescope): add `nvchad` borderless telescope style

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 on:
     push:
+    pull_request:
+        branches:
+            - main
 
 jobs:
     stylua:

--- a/lua/cyberdream/config.lua
+++ b/lua/cyberdream/config.lua
@@ -20,11 +20,13 @@ local M = {}
 ---@field highlights? table<string, table<string, string>>
 ---@field overrides? CyberdreamOverrideFn
 
+---@alias CyberdreamTelescopeStyle "nvchad"
+
 ---@class Config
 ---@field transparent? boolean
 ---@field italic_comments? boolean
 ---@field hide_fillchars? boolean
----@field borderless_telescope? boolean
+---@field borderless_telescope? boolean|{ border: boolean, style: CyberdreamTelescopeStyle }
 ---@field terminal_colors? boolean
 ---@field theme? ThemeConfig
 local default_options = {

--- a/lua/cyberdream/config.lua
+++ b/lua/cyberdream/config.lua
@@ -20,13 +20,13 @@ local M = {}
 ---@field highlights? table<string, table<string, string>>
 ---@field overrides? CyberdreamOverrideFn
 
----@alias CyberdreamTelescopeStyle "nvchad"
+---@alias CyberdreamTelescopeStyle "nvchad" | "flat"
 
 ---@class Config
 ---@field transparent? boolean
 ---@field italic_comments? boolean
 ---@field hide_fillchars? boolean
----@field borderless_telescope? boolean|{ border: boolean, style: CyberdreamTelescopeStyle }
+---@field borderless_telescope? boolean | { border: boolean, style: CyberdreamTelescopeStyle }
 ---@field terminal_colors? boolean
 ---@field theme? ThemeConfig
 local default_options = {

--- a/lua/cyberdream/theme.lua
+++ b/lua/cyberdream/theme.lua
@@ -47,6 +47,13 @@ function M.setup()
         })
     end
 
+    local borderless_telescope = opts.borderless_telescope
+    local telescope_style = ""
+    if type(opts.borderless_telescope) == "table" then
+        borderless_telescope = not opts.borderless_telescope.border
+        telescope_style = opts.borderless_telescope.style
+    end
+
     theme.highlights = {
         Comment = { fg = t.grey, italic = opts.italic_comments },
         ColorColumn = { bg = t.bgHighlight },
@@ -342,16 +349,24 @@ function M.setup()
         ["@keyword"] = { link = "Keyword" },
     }
 
-    if opts.borderless_telescope then
+    if borderless_telescope then
         theme.highlights.TelescopeBorder = { fg = t.bgAlt, bg = t.bgAlt }
         theme.highlights.TelescopeNormal = { bg = t.bgAlt }
         theme.highlights.TelescopePreviewBorder = { fg = t.bgAlt, bg = t.bgAlt }
         theme.highlights.TelescopePreviewNormal = { bg = t.bgAlt }
-        theme.highlights.TelescopePreviewTitle = { fg = t.bgAlt, bg = t.green }
-        theme.highlights.TelescopePromptBorder = { fg = t.bgAlt, bg = t.bgAlt }
-        theme.highlights.TelescopePromptNormal = { fg = t.fg, bg = t.bgAlt }
-        theme.highlights.TelescopePromptPrefix = { fg = t.red, bg = t.bgAlt }
-        theme.highlights.TelescopePromptTitle = { fg = t.bgAlt, bg = t.red }
+        if telescope_style == "nvchad" then
+            theme.highlights.TelescopePreviewTitle = { fg = t.bgAlt, bg = t.green, bold = true }
+            theme.highlights.TelescopePromptBorder = { fg = t.bgHighlight, bg = t.bgHighlight }
+            theme.highlights.TelescopePromptNormal = { fg = t.fg, bg = t.bgHighlight }
+            theme.highlights.TelescopePromptPrefix = { fg = t.red, bg = t.bgHighlight }
+            theme.highlights.TelescopePromptTitle = { fg = t.bgAlt, bg = t.red, bold = true }
+        else
+            theme.highlights.TelescopePreviewTitle = { fg = t.bgAlt, bg = t.green }
+            theme.highlights.TelescopePromptBorder = { fg = t.bgAlt, bg = t.bgAlt }
+            theme.highlights.TelescopePromptNormal = { fg = t.fg, bg = t.bgAlt }
+            theme.highlights.TelescopePromptPrefix = { fg = t.red, bg = t.bgAlt }
+            theme.highlights.TelescopePromptTitle = { fg = t.bgAlt, bg = t.red }
+        end
         theme.highlights.TelescopeResultsBorder = { fg = t.bgAlt, bg = t.bgAlt }
         theme.highlights.TelescopeResultsNormal = { bg = t.bgAlt }
         theme.highlights.TelescopeResultsTitle = { fg = t.bgAlt, bg = t.bgAlt }


### PR DESCRIPTION
@scottmckendry I think it would be a good thing to allow for a separation style borderless telescope, like [NvChad](https://github.com/NvChad/NvChad) "borderless", but allowing for this to be opt-out like [catppuccin](https://github.com/catppuccin/nvim?tab=readme-ov-file#integrations) does in their integrations section.

https://github.com/scottmckendry/cyberdream.nvim/assets/71392160/03ea1fa0-ae81-493c-b0ab-b7f7c421a493

> [!NOTE]
>
> I made it so the changes are compatible with the current way of configuring the colorscheme.
>
> In the video the options are `{ ..., theme = "nvchad" }` but I changed after recording it to `style`

It can be change to be a BREAKING CHANGE and have it like:

```lua
require("cyberdream").setup({
  -- ...
  telescope = {
    borderless = true,
    style = "nvchad",
  },
  -- ...
})
```

The good thing about adding this PR (in my opinion) is that it leads to having styles like `"nvchad_inversed", and do one that it will keep the base `borderless` but light up the results section for example.