### PR TITLE
feat(markup): improve first look readability/distinction

### DIFF
--- a/lua/cyberdream/theme.lua
+++ b/lua/cyberdream/theme.lua
@@ -130,6 +130,7 @@ function M.setup()
         Operator = { fg = t.purple },
         Keyword = { fg = t.orange },
         PreProc = { fg = t.cyan },
+        Label = { fg = t.orange },
 
         Type = { fg = t.purple },
 
@@ -343,11 +344,18 @@ function M.setup()
 
         -- TreeSitter Specific
         ["@variable"] = { fg = t.fg },
-        ["@markup.strong"] = { fg = t.pink, bold = true },
-        ["@markup.italic"] = { fg = t.blue, italic = true },
         ["@boolean"] = { link = "Boolean" },
         ["@number"] = { link = "Number" },
         ["@keyword"] = { link = "Keyword" },
+        -- TreeSitter Markup
+        ["@markup.strong"] = { fg = t.pink, bold = true },
+        ["@markup.italic"] = { fg = t.blue, italic = true },
+        ["@markup.list.unchecked"] = { fg = t.bg_solid, bg = t.magenta, bold = true },
+        ["@markup.list.checked"] = { fg = t.bg_solid, bg = t.green, bold = true },
+        ["@markup.link.label"] = { link = "Label" },
+        ["@markup.link.label.markdown_inline"] = { fg = t.cyan },
+        ["@markup.link.markdown_inline"] = { fg = t.blue },
+        ["@markup.link.url"] = { fg = t.blue, style = "underline" },
     }
 
     if borderless_telescope then

--- a/lua/cyberdream/theme.lua
+++ b/lua/cyberdream/theme.lua
@@ -350,8 +350,8 @@ function M.setup()
         -- TreeSitter Markup
         ["@markup.strong"] = { fg = t.pink, bold = true },
         ["@markup.italic"] = { fg = t.blue, italic = true },
-        ["@markup.list.unchecked"] = { fg = t.bg_solid, bg = t.magenta, bold = true },
-        ["@markup.list.checked"] = { fg = t.bg_solid, bg = t.green, bold = true },
+        ["@markup.list.unchecked"] = { fg = t.magenta, bold = true },
+        ["@markup.list.checked"] = { fg = t.green, bold = true },
         ["@markup.link.label"] = { link = "Label" },
         ["@markup.link.label.markdown_inline"] = { fg = t.cyan },
         ["@markup.link.markdown_inline"] = { fg = t.blue },


### PR DESCRIPTION
@scottmckendry I was writing some `md` file and I notice that there is not much distinction between some treesitter variables.

<img width="1657" alt="No changes made" src="https://github.com/scottmckendry/cyberdream.nvim/assets/71392160/686e5ec3-023d-493d-b02b-4efcaec203e4">

Here are the changes I propose:

<img width="1657" alt="After the changes" src="https://github.com/scottmckendry/cyberdream.nvim/assets/71392160/5b47b826-41b3-4ca4-a951-74eebb37a88f">

In my opinion, I think it improves the readability at a first glance since you can distinguish better the parts.

> [!NOTE]
> I chose this colours, but it can be change, whatever feels better to the general colorscheme.