### PR TITLE
feat: add support for toggleable extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ require("cyberdream").setup({
     extensions = {
         telescope = true,
         notify = true,
+        mini = true,
         ...
     },
 })

--- a/README.md
+++ b/README.md
@@ -141,8 +141,18 @@ require("cyberdream").setup({
             magenta = "#ff00ff",
         },
     },
+
+    -- Disable or enable colorscheme extensions
+    extensions = {
+        telescope = true,
+        notify = true,
+        ...
+    },
 })
 ```
+
+> [!NOTE]
+> For a complete list of extensions, see the [table in `config.lua`](lua/cyberdream/config.lua).
 
 ## 🧑‍🍳 Recipes
 

--- a/doc/cyberdream.txt
+++ b/doc/cyberdream.txt
@@ -131,9 +131,20 @@ their default values:
                 magenta = "#ff00ff",
             },
         },
+    
+        -- Disable or enable colorscheme extensions
+        extensions = {
+            telescope = true,
+            notify = true,
+            mini = true,
+            ...
+        },
     })
 <
 
+
+  [!NOTE] For a complete list of extensions, see the table in `config.lua`
+  <lua/cyberdream/config.lua>.
 
 ‍ RECIPES                                           *cyberdream-‍-recipes*
 

--- a/lua/cyberdream/config.lua
+++ b/lua/cyberdream/config.lua
@@ -25,6 +25,7 @@ local M = {}
 ---@class extensions
 ---@field telescope? boolean
 ---@field notify? boolean
+---@field mini? boolean
 
 ---@class Config
 ---@field transparent? boolean
@@ -50,6 +51,7 @@ local default_options = {
     extensions = {
         telescope = true,
         notify = true,
+        mini = true,
     },
 }
 

--- a/lua/cyberdream/config.lua
+++ b/lua/cyberdream/config.lua
@@ -22,6 +22,10 @@ local M = {}
 
 ---@alias CyberdreamTelescopeStyle "nvchad" | "flat"
 
+---@class extensions
+---@field telescope? boolean
+---@field notify? boolean
+
 ---@class Config
 ---@field transparent? boolean
 ---@field italic_comments? boolean
@@ -29,6 +33,7 @@ local M = {}
 ---@field borderless_telescope? boolean | { border: boolean, style: CyberdreamTelescopeStyle }
 ---@field terminal_colors? boolean
 ---@field theme? ThemeConfig
+---@field extensions? extensions
 local default_options = {
     transparent = false,
     italic_comments = false,
@@ -40,6 +45,11 @@ local default_options = {
         variant = "default",
         colors = {},
         highlights = {},
+    },
+
+    extensions = {
+        telescope = true,
+        notify = true,
     },
 }
 

--- a/lua/cyberdream/extensions/mini.lua
+++ b/lua/cyberdream/extensions/mini.lua
@@ -1,0 +1,20 @@
+local util = require("cyberdream.util")
+local M = {}
+
+--- Get extension configuration
+--- @param opts Config
+--- @param t CyberdreamPalette
+function M.get(_, t)
+    local highlights = {
+        -- Mini Files
+        MiniFilesBorder = { fg = t.bgHighlight },
+        MiniFilesBorderModified = { fg = t.pink },
+        MiniFilesCursorLine = { bg = util.blend(t.bgHighlight, t.bgAlt, 0.3) },
+        MiniFilesDirectory = { fg = t.blue },
+        MiniFilesTitle = { fg = util.blend(t.bgHighlight, t.cyan, 0.7) },
+        MiniFilesTitleFocused = { fg = t.cyan },
+    }
+
+    return highlights
+end
+return M

--- a/lua/cyberdream/extensions/notify.lua
+++ b/lua/cyberdream/extensions/notify.lua
@@ -1,0 +1,36 @@
+local M = {}
+
+--- Get extension configuration
+--- @param opts Config
+--- @param t CyberdreamPalette
+function M.get(opts, t)
+    local highlights = {
+        NotifyDEBUGBody = { fg = t.fg },
+        NotifyDEBUGBorder = { fg = t.bgHighlight },
+        NotifyDEBUGIcon = { fg = t.grey },
+        NotifyDEBUGTitle = { fg = t.grey },
+        NotifyERRORBody = { fg = t.fg },
+        NotifyERRORBorder = { fg = t.bgHighlight },
+        NotifyERRORIcon = { fg = t.red },
+        NotifyERRORTitle = { fg = t.pink },
+        NotifyINFOBody = { fg = t.fg },
+        NotifyINFOBorder = { fg = t.bgHighlight },
+        NotifyINFOIcon = { fg = t.green },
+        NotifyINFOTitle = { fg = t.cyan },
+        NotifyTRACEBorder = { fg = t.bgHighlight },
+        NotifyTRACEIcon = { fg = t.purple },
+        NotifyTRACETitle = { fg = t.magenta },
+        NotifyWARNBody = { fg = t.fg },
+        NotifyWARNBorder = { fg = t.bgHighlight },
+        NotifyWARNIcon = { fg = t.orange },
+        NotifyWARNTitle = { fg = t.yellow },
+        NotifyBackground = { bg = t.bg },
+    }
+
+    if opts.transparent then
+        highlights.NotifyBackground = { bg = "#000000" }
+    end
+
+    return highlights
+end
+return M

--- a/lua/cyberdream/extensions/telescope.lua
+++ b/lua/cyberdream/extensions/telescope.lua
@@ -1,0 +1,55 @@
+local M = {}
+
+--- Get extension configuration
+--- @param opts Config
+--- @param t CyberdreamPalette
+function M.get(opts, t)
+    local borderless_telescope = opts.borderless_telescope
+    local telescope_style = ""
+    if type(opts.borderless_telescope) == "table" then
+        borderless_telescope = not opts.borderless_telescope.border
+        telescope_style = opts.borderless_telescope.style
+    end
+
+    local highlights = {
+        TelescopeBorder = { fg = t.bgHighlight },
+        TelescopePromptTitle = { fg = t.blue },
+        TelescopeResultsTitle = { fg = t.cyan },
+        TelescopePromptPrefix = { fg = t.pink },
+        TelescopePreviewTitle = { fg = t.magenta },
+        TelescopeSelection = { bg = t.bgHighlight },
+        TelescopePromptCounter = { fg = t.pink },
+    }
+
+    if borderless_telescope then
+        highlights.TelescopeBorder = { fg = t.bgAlt, bg = t.bgAlt }
+        highlights.TelescopeNormal = { bg = t.bgAlt }
+        highlights.TelescopePreviewBorder = { fg = t.bgAlt, bg = t.bgAlt }
+        highlights.TelescopePreviewNormal = { bg = t.bgAlt }
+        if telescope_style == "nvchad" then
+            highlights.TelescopePreviewTitle = { fg = t.bgAlt, bg = t.green, bold = true }
+            highlights.TelescopePromptBorder = { fg = t.bgHighlight, bg = t.bgHighlight }
+            highlights.TelescopePromptNormal = { fg = t.fg, bg = t.bgHighlight }
+            highlights.TelescopePromptPrefix = { fg = t.red, bg = t.bgHighlight }
+            highlights.TelescopePromptTitle = { fg = t.bgAlt, bg = t.red, bold = true }
+        else
+            highlights.TelescopePreviewTitle = { fg = t.bgAlt, bg = t.green }
+            highlights.TelescopePromptBorder = { fg = t.bgAlt, bg = t.bgAlt }
+            highlights.TelescopePromptNormal = { fg = t.fg, bg = t.bgAlt }
+            highlights.TelescopePromptPrefix = { fg = t.red, bg = t.bgAlt }
+            highlights.TelescopePromptTitle = { fg = t.bgAlt, bg = t.red }
+        end
+        highlights.TelescopeResultsBorder = { fg = t.bgAlt, bg = t.bgAlt }
+        highlights.TelescopeResultsNormal = { bg = t.bgAlt }
+        highlights.TelescopeResultsTitle = { fg = t.bgAlt, bg = t.bgAlt }
+
+        -- Mimic styling in Grapple
+        highlights.GrappleNormal = { bg = t.bgAlt }
+        highlights.GrappleBorder = { fg = t.bgAlt, bg = t.bgAlt }
+        highlights.GrappleTitle = { fg = t.bgAlt, bg = t.cyan }
+    end
+
+    return highlights
+end
+
+return M

--- a/lua/cyberdream/theme.lua
+++ b/lua/cyberdream/theme.lua
@@ -48,13 +48,6 @@ function M.setup()
         })
     end
 
-    local borderless_telescope = opts.borderless_telescope
-    local telescope_style = ""
-    if type(opts.borderless_telescope) == "table" then
-        borderless_telescope = not opts.borderless_telescope.border
-        telescope_style = opts.borderless_telescope.style
-    end
-
     theme.highlights = {
         Comment = { fg = t.grey, italic = opts.italic_comments },
         ColorColumn = { bg = t.bgHighlight },
@@ -225,15 +218,6 @@ function M.setup()
         DashboardFiles = { fg = t.cyan },
         DashboardShortCutIcon = { fg = t.pink },
 
-        -- Telescope
-        TelescopeBorder = { fg = t.bgHighlight },
-        TelescopePromptTitle = { fg = t.blue },
-        TelescopeResultsTitle = { fg = t.cyan },
-        TelescopePromptPrefix = { fg = t.pink },
-        TelescopePreviewTitle = { fg = t.magenta },
-        TelescopeSelection = { bg = t.bgHighlight },
-        TelescopePromptCounter = { fg = t.pink },
-
         -- Cmp
         CmpDocumentation = { fg = t.grey, bg = t.bg },
         CmpDocumentationBorder = { fg = t.grey, bg = t.bg },
@@ -299,28 +283,6 @@ function M.setup()
         HeirlineInsert = { bg = t.green },
         HeirlineTerminal = { bg = t.cyan },
 
-        -- Nvim Notify
-        NotifyDEBUGBody = { fg = t.fg },
-        NotifyDEBUGBorder = { fg = t.bgHighlight },
-        NotifyDEBUGIcon = { fg = t.grey },
-        NotifyDEBUGTitle = { fg = t.grey },
-        NotifyERRORBody = { fg = t.fg },
-        NotifyERRORBorder = { fg = t.bgHighlight },
-        NotifyERRORIcon = { fg = t.red },
-        NotifyERRORTitle = { fg = t.pink },
-        NotifyINFOBody = { fg = t.fg },
-        NotifyINFOBorder = { fg = t.bgHighlight },
-        NotifyINFOIcon = { fg = t.green },
-        NotifyINFOTitle = { fg = t.cyan },
-        NotifyTRACEBorder = { fg = t.bgHighlight },
-        NotifyTRACEIcon = { fg = t.purple },
-        NotifyTRACETitle = { fg = t.magenta },
-        NotifyWARNBody = { fg = t.fg },
-        NotifyWARNBorder = { fg = t.bgHighlight },
-        NotifyWARNIcon = { fg = t.orange },
-        NotifyWARNTitle = { fg = t.yellow },
-        NotifyBackground = { bg = t.bg },
-
         -- Indent Blankline
         IblIndent = { fg = util.blend(t.bgHighlight, t.bgAlt, 0.3) },
         IblScope = { fg = t.bgHighlight },
@@ -358,34 +320,6 @@ function M.setup()
         ["@markup.link.url"] = { fg = t.blue, style = "underline" },
     }
 
-    if borderless_telescope then
-        theme.highlights.TelescopeBorder = { fg = t.bgAlt, bg = t.bgAlt }
-        theme.highlights.TelescopeNormal = { bg = t.bgAlt }
-        theme.highlights.TelescopePreviewBorder = { fg = t.bgAlt, bg = t.bgAlt }
-        theme.highlights.TelescopePreviewNormal = { bg = t.bgAlt }
-        if telescope_style == "nvchad" then
-            theme.highlights.TelescopePreviewTitle = { fg = t.bgAlt, bg = t.green, bold = true }
-            theme.highlights.TelescopePromptBorder = { fg = t.bgHighlight, bg = t.bgHighlight }
-            theme.highlights.TelescopePromptNormal = { fg = t.fg, bg = t.bgHighlight }
-            theme.highlights.TelescopePromptPrefix = { fg = t.red, bg = t.bgHighlight }
-            theme.highlights.TelescopePromptTitle = { fg = t.bgAlt, bg = t.red, bold = true }
-        else
-            theme.highlights.TelescopePreviewTitle = { fg = t.bgAlt, bg = t.green }
-            theme.highlights.TelescopePromptBorder = { fg = t.bgAlt, bg = t.bgAlt }
-            theme.highlights.TelescopePromptNormal = { fg = t.fg, bg = t.bgAlt }
-            theme.highlights.TelescopePromptPrefix = { fg = t.red, bg = t.bgAlt }
-            theme.highlights.TelescopePromptTitle = { fg = t.bgAlt, bg = t.red }
-        end
-        theme.highlights.TelescopeResultsBorder = { fg = t.bgAlt, bg = t.bgAlt }
-        theme.highlights.TelescopeResultsNormal = { bg = t.bgAlt }
-        theme.highlights.TelescopeResultsTitle = { fg = t.bgAlt, bg = t.bgAlt }
-
-        -- Mimic styling in Grapple
-        theme.highlights.GrappleNormal = { bg = t.bgAlt }
-        theme.highlights.GrappleBorder = { fg = t.bgAlt, bg = t.bgAlt }
-        theme.highlights.GrappleTitle = { fg = t.bgAlt, bg = t.cyan }
-    end
-
     if opts.terminal_colors then
         vim.g.terminal_color_0 = t.bg
         vim.g.terminal_color_8 = t.bgAlt
@@ -412,16 +346,20 @@ function M.setup()
         vim.g.terminal_color_14 = t.cyan
     end
 
-    -- Use #000000 for full transparency
-    if opts.transparent then
-        theme.highlights.NotifyBackground = { bg = "#000000" }
+    -- Load enabled extensions
+    local extensions = opts.extensions or {}
+    for extension, enabled in pairs(extensions) do
+        if enabled then
+            local ext = require("cyberdream.extensions." .. extension)
+            theme.highlights = vim.tbl_deep_extend("force", theme.highlights, ext.get(opts, t))
+        end
     end
 
+    -- Parse user defined overrides and apply them
     local overrides = opts.theme.overrides or opts.theme.highlights
     if type(overrides) == "function" then
         overrides = overrides(t)
     end
-    -- Override highlights with user defined highlights
     theme.highlights = vim.tbl_deep_extend("force", theme.highlights, overrides or {})
 
     return theme

--- a/lua/cyberdream/theme.lua
+++ b/lua/cyberdream/theme.lua
@@ -291,14 +291,6 @@ function M.setup()
         TreeSitterContext = { bg = util.blend(t.bgAlt, t.cyan, 0.9) },
         TreeSitterContextLineNumber = { fg = util.blend(t.bgHighlight, t.fg) },
 
-        -- Mini Files
-        MiniFilesBorder = { fg = t.bgHighlight },
-        MiniFilesBorderModified = { fg = t.pink },
-        MiniFilesCursorLine = { bg = util.blend(t.bgHighlight, t.bgAlt, 0.3) },
-        MiniFilesDirectory = { fg = t.blue },
-        MiniFilesTitle = { fg = util.blend(t.bgHighlight, t.cyan, 0.7) },
-        MiniFilesTitleFocused = { fg = t.cyan },
-
         -- Grapple
         GrappleTitle = { fg = t.pink },
         GrappleFooter = { fg = t.grey },


### PR DESCRIPTION
This PR adds some new logic the `theme.lua` file to improve its modularity and provide greater flexibility when adding new plugins or variations on the default theme. This is inspired by Catppuccin's approach.

It should be a good starting point for implementing #81 

Big thanks to @AlejandroSuero for the advice in #79 💚