### PR TITLE
docs(extras): add wezterm usage example

### DIFF
--- a/extras/wezterm/README.md
+++ b/extras/wezterm/README.md
@@ -1,0 +1,8 @@
+## Usage
+
+1. Save `cyberdream.lua` to `~/.config/wezterm/`
+2. Add the following line to your `~/.config/wezterm/wezterm.lua` file:
+
+```lua
+config.colors = require("cyberdream")
+```


### PR DESCRIPTION
Not a huge contribution, I am completely new to the whole lua/wezterm/nvim world, and I just discovered your theme, fell in love with it, noticed you have an[ open issue](https://github.com/scottmckendry/cyberdream.nvim/issues/44) for missing docs, and since I just configured cyberdream for wezterm, thought I can at least contribute with this.

Keep up the good work and thanks again!