### PR TITLE
fix(kitty.conf): base16 correction on brights (color8)

### DIFF
--- a/extras/kitty/cyberdream.conf
+++ b/extras/kitty/cyberdream.conf
@@ -5,7 +5,7 @@ cursor                #ffffff
 cursor_text_color     #16181a
 selection_background  #3c4048
 color0                #16181a
-color8                #16181a
+color8                #3c4048
 color1                #ff6e5e
 color9                #ff6e5e
 color2                #5eff6c

--- a/lua/cyberdream/extra/kitty.lua
+++ b/lua/cyberdream/extra/kitty.lua
@@ -15,7 +15,7 @@ cursor                ${fg}
 cursor_text_color     ${bg}
 selection_background  ${bgHighlight}
 color0                ${bg}
-color8                ${bg}
+color8                ${bgHighlight}
 color1                ${red}
 color9                ${red}
 color2                ${green}


### PR DESCRIPTION
If color0 and color8 are the same, the zsh-autosuggestions are the same colour as the background making it difficult to read.

I used the wezterm config as reference and found that the color8 used in this config was incorrect thus fixed.