### PR TITLE
Add kitty tabs colors

### DIFF
--- a/extras/kitty/cyberdream.conf
+++ b/extras/kitty/cyberdream.conf
@@ -21,3 +21,7 @@ color14               #5ef1ff
 color7                #ffffff
 color15               #ffffff
 selection_foreground  #ffffff
+active_tab_foreground   #000
+active_tab_background   #ffbd5e
+inactive_tab_foreground #ffffff
+inactive_tab_background #16181a

--- a/lua/cyberdream/extra/kitty.lua
+++ b/lua/cyberdream/extra/kitty.lua
@@ -31,6 +31,10 @@ color14               ${cyan}
 color7                ${fg}
 color15               ${fg}
 selection_foreground  ${fg}
+active_tab_foreground ${fg}
+active_tab_background ${orange}
+inactive_tab_foreground ${fg}
+inactive_tab_background ${bg}
 ]==]
 
     return util.parse_extra_template(template, t)


### PR DESCRIPTION
The proposed kitty themes missing the config for tabs which is really essential for kitty. All white config makes it look really weird for the high contrast themes, so I added the combination I think fits really well.

Here is how it looked before 

<img width="1230" alt="image" src="https://github.com/user-attachments/assets/d967624d-3bc6-40fe-976c-5a4b9165a0e4" />

Here is after 

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/2a58e5aa-9b5a-41b5-819d-b1eb5f58b7f3" />
