### PR TITLE
Make whitespace less contrast

### DIFF
--- a/lua/cyberdream/extensions/base.lua
+++ b/lua/cyberdream/extensions/base.lua
@@ -68,7 +68,7 @@ function M.get(opts, t)
         Visual = { bg = t.bgHighlight },
         VisualNOS = { bg = t.bgHighlight },
         WarningMsg = { fg = t.orange },
-        Whitespace = { fg = t.grey },
+        Whitespace = { fg = t.bgHighlight },
         WildMenu = { fg = t.bg, bg = t.blue },
 
         Constant = { fg = t.pink },


### PR DESCRIPTION
I am the heavy user of vim.list to display whitespace character and the default gray color is too contrast for it. It should not be the same color as comments notice how weird it looks with the dots everywhere

<img width="1106" alt="image" src="https://github.com/user-attachments/assets/768446ce-a4d3-4d7b-a6e8-8b316f84a782" />

after my change it is much better
<img width="1121" alt="image" src="https://github.com/user-attachments/assets/e44e7cc9-1364-456f-a252-d84c5048b4bd" />
