### PR TITLE
fix(extensions): remove BlinkCmpLabel bg

### DIFF
--- a/lua/cyberdream/extensions/blinkcmp.lua
+++ b/lua/cyberdream/extensions/blinkcmp.lua
@@ -10,7 +10,7 @@ function M.get(opts, t)
         BlinkCmpMenu = { link = "Pmenu" },
         BlinkCmpMenuBorder = { fg = util.blend(t.bgHighlight, t.grey, 0.7) },
         BlinkCmpMenuSelection = { bg = t.bgHighlight },
-        BlinkCmpLabel = { link = "Normal" },
+        BlinkCmpLabel = { fg = t.fg },
         BlinkCmpLabelDeprecated = { fg = t.grey, strikethrough = true },
         BlinkCmpLabelMatch = { fg = t.cyan },
         BlinkCmpDoc = { link = "NormalFloat" },


### PR DESCRIPTION
- before:
<img width="864" alt="SCR-20241229-ktaw" src="https://github.com/user-attachments/assets/2a3a81e2-6dc9-4cc9-985d-569d76a6aec7" />

- after:
<img width="878" alt="SCR-20241229-ktgp" src="https://github.com/user-attachments/assets/300d1658-3386-41c6-b1a0-edffff8840a7" />

hi, I think BlinkCmpLabel should not have a bg here