### PR TITLE
feat(extras): add foot terminal extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ We've cooked up some wonderful extras to enhance your cyberdream experience. Mos
 - **[Yazi](extras/yazi/)**
 - **[Zed](extras/zed/)**
 - **[Zellij](extras/zellij/)**
+- **[Foot](extras/foot/)**
 
 ## 🧑‍🍳 Recipes
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ We've cooked up some wonderful extras to enhance your cyberdream experience. Mos
 - **[Alacritty](extras/alacritty/)**
 - **[Base16/Stylix](extras/base16/)**
 - **[Fish](extras/fish/)**
+- **[Foot](extras/foot/)**
 - **[Ghostty](extras/ghostty/)**
 - **[GitUI](extras/gitui/)**
 - **[Helix](extras/helix/)**
@@ -229,7 +230,6 @@ We've cooked up some wonderful extras to enhance your cyberdream experience. Mos
 - **[Yazi](extras/yazi/)**
 - **[Zed](extras/zed/)**
 - **[Zellij](extras/zellij/)**
-- **[Foot](extras/foot/)**
 
 ## 🧑‍🍳 Recipes
 

--- a/extras/foot/README.md
+++ b/extras/foot/README.md
@@ -1,0 +1,14 @@
+## Usage
+
+1. Save `cyberdream.ini` or `cyberdream-light.ini` to `~/.config/foot/`
+2. Add the following line to `[main]` section of your `~/.config/foot/foot.ini`:
+
+```ini
+include=~/.config/foot/cyberdream.ini
+```
+
+Or, if using light theme:
+
+```ini
+include=~/.config/foot/cyberdream-light.ini
+```

--- a/extras/foot/cyberdream-light.ini
+++ b/extras/foot/cyberdream-light.ini
@@ -1,0 +1,26 @@
+# Cyberdream theme for foot terminal
+[cursor]
+color=      ffffff 16181a
+
+[colors]
+background= ffffff
+foreground= 16181a
+# The  eight basic ANSI colors (Black, Red, Green, Yellow, Blue, Magenta, Cyan, White)
+regular0=   ffffff
+regular1=   d11500
+regular2=   008b0c
+regular3=   997b00
+regular4=   0057d1
+regular5=   a018ff
+regular6=   008c99
+regular7=   16181a
+# The eight bright ANSI colors (Black, Red, Green, Yellow, Blue, Magenta, Cyan, White)
+bright0=    acacac
+bright1=    d11500
+bright2=    008b0c
+bright3=    997b00
+bright4=    0057d1
+bright5=    a018ff
+bright6=    008c99
+bright7=    16181a
+bright7=    16181a

--- a/extras/foot/cyberdream.ini
+++ b/extras/foot/cyberdream.ini
@@ -1,0 +1,26 @@
+# Cyberdream theme for foot terminal
+[cursor]
+color=      16181a ffffff
+
+[colors]
+background= 16181a
+foreground= ffffff
+# The  eight basic ANSI colors (Black, Red, Green, Yellow, Blue, Magenta, Cyan, White)
+regular0=   16181a
+regular1=   ff6e5e
+regular2=   5eff6c
+regular3=   f1ff5e
+regular4=   5ea1ff
+regular5=   bd5eff
+regular6=   5ef1ff
+regular7=   ffffff
+# The eight bright ANSI colors (Black, Red, Green, Yellow, Blue, Magenta, Cyan, White)
+bright0=    3c4048
+bright1=    ff6e5e
+bright2=    5eff6c
+bright3=    f1ff5e
+bright4=    5ea1ff
+bright5=    bd5eff
+bright6=    5ef1ff
+bright7=    ffffff
+bright7=    ffffff

--- a/lua/cyberdream/extra/foot.lua
+++ b/lua/cyberdream/extra/foot.lua
@@ -1,0 +1,58 @@
+local colors = require("cyberdream.colors")
+local util = require("cyberdream.util")
+
+local M = {}
+
+--- Format colors for foot, removing #
+--- @param hex string: The hex color to format. Must be in the format "#RRGGBB".
+local function format_color(hex)
+    return string.sub(hex, 2)
+end
+
+--- Iterate over the colors in a table and format them.
+--- @param t table: The table of colors to format.
+local function format_colors(t)
+    local formatted = {}
+    for k, v in pairs(t) do
+        formatted[k] = format_color(v)
+    end
+    return formatted
+end
+
+--- Generate the theme for kitty.
+--- @param variant string: Variation of the colorscheme to use.
+function M.generate(variant)
+    local t = format_colors(colors[variant])
+    local template = [==[
+# Cyberdream theme for foot terminal
+[cursor]
+color=      ${bg} ${fg}
+
+[colors]
+background= ${bg}
+foreground= ${fg}
+# The  eight basic ANSI colors (Black, Red, Green, Yellow, Blue, Magenta, Cyan, White)
+regular0=   ${bg}
+regular1=   ${red}
+regular2=   ${green}
+regular3=   ${yellow}
+regular4=   ${blue}
+regular5=   ${purple}
+regular6=   ${cyan}
+regular7=   ${fg}
+# The eight bright ANSI colors (Black, Red, Green, Yellow, Blue, Magenta, Cyan, White)
+bright0=    ${bgHighlight}
+bright1=    ${red}
+bright2=    ${green}
+bright3=    ${yellow}
+bright4=    ${blue}
+bright5=    ${purple}
+bright6=    ${cyan}
+bright7=    ${fg}
+bright7=    ${fg}
+]==]
+
+    return util.parse_extra_template(template, t)
+end
+
+return M

--- a/lua/cyberdream/extra/init.lua
+++ b/lua/cyberdream/extra/init.lua
@@ -9,6 +9,7 @@ M.extras = {
     alacritty = { extension = "toml", name = "alacritty" },
     base16 = { extension = "yaml", name = "base16" },
     fish = { extension = "theme", name = "fish" },
+    foot = { extension = "ini", name = "foot" },
     ghostty = { extension = nil, name = "ghostty" },
     gitui = { extension = "ron", name = "gitui" },
     helix = { extension = "toml", name = "helix" },
@@ -28,7 +29,6 @@ M.extras = {
     yazi = { extension = "toml", name = "yazi" },
     zellij = { extension = "kdl", name = "zellij" },
     zed = { extension = "json", name = "zed" },
-    foot = { extension = "ini", name = "foot" },
 }
 
 --- Create/overwrite a file in the extras directory.

--- a/lua/cyberdream/extra/init.lua
+++ b/lua/cyberdream/extra/init.lua
@@ -28,6 +28,7 @@ M.extras = {
     yazi = { extension = "toml", name = "yazi" },
     zellij = { extension = "kdl", name = "zellij" },
     zed = { extension = "json", name = "zed" },
+    foot = { extension = "ini", name = "foot" },
 }
 
 --- Create/overwrite a file in the extras directory.


### PR DESCRIPTION
Added a template to generate the colorscheme for the [foot terminal](https://codeberg.org/dnkl/foot) :)

![image](https://github.com/user-attachments/assets/3ad0a9d3-d789-4e87-8218-ab07a271461b)
