### PR TITLE
nvim: change CursorLine, CursorColumn and ColorColumn to distinguish it with Visual

### DIFF
--- a/lua/cyberdream/extensions/base.lua
+++ b/lua/cyberdream/extensions/base.lua
@@ -8,13 +8,13 @@ function M.get(opts, t)
     opts = opts or {}
     local highlights = {
         Comment = { fg = t.grey, italic = opts.italic_comments },
-        ColorColumn = { bg = t.bg_highlight },
+        ColorColumn = { bg = util.blend(t.bg_solid, t.bg_highlight, 0.55) },
         Conceal = { fg = t.grey },
         Cursor = { fg = t.bg, bg = t.fg },
         ICursor = { fg = t.bg, bg = t.fg },
         CursorIM = { fg = t.bg, bg = t.fg },
-        CursorColumn = { bg = t.bg_highlight },
-        CursorLine = { bg = t.bg_highlight },
+        CursorColumn = { bg = util.blend(t.bg_solid, t.bg_highlight, 0.55) },
+        CursorLine = { bg = util.blend(t.bg_solid, t.bg_highlight, 0.55) },
         Directory = { fg = t.blue },
         DiffAdd = { bg = util.blend(t.bg_solid, t.green, 0.8) },
         DiffChange = { bg = util.blend(t.bg_solid, t.blue, 0.8) },


### PR DESCRIPTION
Current wezterm selection colors are same as nvim's line colors. This makes it hard to spot which part of text is selected.

This patch makes selection colors more distinct.

Before -
![image](https://github.com/user-attachments/assets/4a00d798-6fde-4deb-a673-240255820986)


After -
![image](https://github.com/user-attachments/assets/f9daf3bc-aaa3-434e-8d7b-3486bbd5bc97)

Update 1:

Changed CursorLine and ColorColumn to distinguish it with Visual

After -
![image](https://github.com/user-attachments/assets/78113c2f-521b-413e-a8bf-4b324d8b7b3d)

