### PR TITLE
feat(extensions): render-markdown.nvim nested block quote groups

### DIFF
--- a/lua/cyberdream/extensions/markdown.lua
+++ b/lua/cyberdream/extensions/markdown.lua
@@ -21,9 +21,16 @@ function M.get(opts, t)
         RenderMarkdownH5Bg = { bg = util.blend(t.bg_solid, t.magenta, 0.85) },
         RenderMarkdownH6Bg = { bg = util.blend(t.bg_solid, t.green, 0.85) },
 
+        RenderMarkdownQuote = { fg = t.grey },
+        RenderMarkdownQuote1 = { fg = util.blend(t.grey, t.bg_solid, 0.9) },
+        RenderMarkdownQuote2 = { fg = util.blend(t.grey, t.bg_solid, 0.8) },
+        RenderMarkdownQuote3 = { fg = util.blend(t.grey, t.bg_solid, 0.7) },
+        RenderMarkdownQuote4 = { fg = util.blend(t.grey, t.bg_solid, 0.6) },
+        RenderMarkdownQuote5 = { fg = util.blend(t.grey, t.bg_solid, 0.5) },
+        RenderMarkdownQuote6 = { fg = util.blend(t.grey, t.bg_solid, 0.4) },
+
         RenderMarkdownCode = { bg = t.bg_alt },
         RenderMarkdownBullet = { fg = t.grey },
-        RenderMarkdownQuote = { link = "Comment" },
         RenderMarkdownDash = { fg = t.grey },
         RenderMarkdownLink = { link = "@markup.link.label.markdown_inline" },
         RenderMarkdownMath = { link = "@markup.math" },


### PR DESCRIPTION
[render-markdown.nvim](https://github.com/MeanderingProgrammer/render-markdown.nvim) now supports setting block quote markers to highlights based on the nesting level of the particular marker.

Following commit [7051859](https://github.com/MeanderingProgrammer/render-markdown.nvim/commit/70518594a4bf1a35d4e331677dd86bc065e599a4) the default has also been updated to have highlights for 6 levels, but out of the box they all link to the same highlight.

Wanted test out how they would look with some colorschemes. LMK if you prefer a different coloring or you just want to keep the single color. I also made a more colorful version that I can push instead, but thought it might be a bit much haha.

| Before | After | More Colorful |
| ------ | ----- | -------------- |
| <img width="290" alt="before" src="https://github.com/user-attachments/assets/05edfeed-8347-488b-9b2e-bddae55db40b" /> | <img width="290" alt="after" src="https://github.com/user-attachments/assets/13a5d918-b51a-4f2e-8456-13112a6731d8" /> | <img width="290" alt="colorful" src="https://github.com/user-attachments/assets/c276d762-a514-47ed-a0c7-5707d620c486" /> |