### PR TITLE
feat: Option to show EndOfBuffer characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ require("cyberdream").setup({
     -- Replace all fillchars with ' ' for the ultimate clean look
     hide_fillchars = false,
 
+    -- Show end of buffer tilde characters for a default look
+    show_eob = false,
+
     -- Apply a modern borderless look to pickers like Telescope, Snacks Picker & Fzf-Lua
     borderless_pickers = false,
 

--- a/lua/cyberdream/cache.lua
+++ b/lua/cyberdream/cache.lua
@@ -55,10 +55,12 @@ M.load_options = function(theme)
             verthoriz = " ",
             eob = " ",
         })
-    else
-        vim.opt.fillchars:append({
-            eob = " ",
-        })
+
+        if not theme.config.show_eob then
+            vim.opt.fillchars:append({
+                eob = " ",
+            })
+        end
     end
 
     if theme.terminal_colors then

--- a/lua/cyberdream/config.lua
+++ b/lua/cyberdream/config.lua
@@ -67,6 +67,7 @@ local default_options = {
     highlights = {},
     italic_comments = false,
     hide_fillchars = false,
+    show_eob = false,
     borderless_pickers = false,
     terminal_colors = true,
     cache = false,

--- a/lua/cyberdream/extensions/base.lua
+++ b/lua/cyberdream/extensions/base.lua
@@ -22,7 +22,7 @@ function M.get(opts, t)
         DiffText = { bg = util.blend(t.bg_solid, t.orange, 0.8) },
         Added = { fg = t.green },
         Removed = { fg = t.red },
-        EndOfBuffer = { fg = t.bg },
+        EndOfBuffer = opts.show_eob and { fg = util.blend(t.bg_highlight, t.fg, 0.9) } or { fg = t.bg },
         ErrorMsg = { fg = t.red },
         VertSplit = { fg = t.bg_highlight, bg = t.bg },
         WinSeparator = { fg = t.bg_highlight, bg = t.bg },

--- a/lua/cyberdream/theme.lua
+++ b/lua/cyberdream/theme.lua
@@ -62,7 +62,9 @@ function M.setup(variant)
             verthoriz = " ",
             eob = " ",
         })
-    else
+    end
+
+    if not opts.show_eob then
         vim.opt.fillchars:append({
             eob = " ",
         })


### PR DESCRIPTION
# show_eob

Hey Scott, been loving the colorscheme for neovim and ghostty :)

I noticed no tildes for end of buffer, which is helpful for some config files. I had a work-around to see them, but I wanted to contribute the ability who wants it also.

One thing I debated was whether to change the EndOfBuffer color depending on the feature. This lets them be useful for folks who are doing e.g. `:set fillchars&` if they temporarily want to see them.

This is my first time contributing to lua nvim and my first PR to a big colorscheme.

## Summary
This change adds `opts.show_eob` which defaults to the existing behavior. Setting the option to true then they see the EOB tildes.

## Examples
Defaults dark, light:
<img width="656" height="645" alt="Screenshot From 2025-11-10 20-27-08 (Edit)" src="https://github.com/user-attachments/assets/97cb507b-b1a3-4754-b025-dda807abcf84" />
<img width="656" height="645" alt="Screenshot From 2025-11-10 20-27-18" src="https://github.com/user-attachments/assets/e923a486-8eed-4b50-a9cc-63ef4f81296a" />

Hide fillchars on looks the same, dark, light:
<img width="656" height="645" alt="Screenshot From 2025-11-10 20-29-15" src="https://github.com/user-attachments/assets/70b3d9b4-6aba-4dfc-b0e4-0c551a687afe" />
<img width="656" height="645" alt="Screenshot From 2025-11-10 20-29-23" src="https://github.com/user-attachments/assets/50acd8d7-0915-4116-8eeb-a4bdb3601aaa" />

Show-eob on:
<img width="656" height="645" alt="Screenshot From 2025-11-10 20-31-37" src="https://github.com/user-attachments/assets/7625fc5f-5b0b-45ae-8dc8-2e9432b0c835" />
<img width="656" height="645" alt="Screenshot From 2025-11-10 20-33-09" src="https://github.com/user-attachments/assets/d9c047f5-24c7-489f-bf74-0eebd54b44cc" />
