### PR TITLE
Empower fillchars false

### DIFF
--- a/lua/cyberdream/extensions/base.lua
+++ b/lua/cyberdream/extensions/base.lua
@@ -22,7 +22,7 @@ function M.get(opts, t)
         DiffText = { bg = util.blend(t.bg_solid, t.orange, 0.8) },
         Added = { fg = t.green },
         Removed = { fg = t.red },
-        EndOfBuffer = { fg = t.bg },
+        EndOfBuffer = { fg = util.blend(t.bg_highlight, t.fg, 0.9) },
         ErrorMsg = { fg = t.red },
         VertSplit = { fg = t.bg_highlight, bg = t.bg },
         WinSeparator = { fg = t.bg_highlight, bg = t.bg },

--- a/lua/cyberdream/theme.lua
+++ b/lua/cyberdream/theme.lua
@@ -62,10 +62,6 @@ function M.setup(variant)
             verthoriz = " ",
             eob = " ",
         })
-    else
-        vim.opt.fillchars:append({
-            eob = " ",
-        })
     end
 
     if opts.terminal_colors then


### PR DESCRIPTION
Following on discussion in #202 this PR takes another approach to fillchars.

Here's the new approach:

- `hide_fillchars` absent or `nil` in the theme options shows what the colorscheme shows today.
- `hide_fillchars = true` also hides all fillchars just as it does today for existing configs.
- `hide_fillchars = false` changes to not hide the EOB fillchar, which leaves fillchars untouched by cyberdream.

It may be a code-smell to use nil as a third state, but this seemed to be the reasonable approach to take to break the fewest setups. Again see #202 for other details and screenshots.
