### PR TITLE
✨ feat(extras): Add delta extra and related docs for theme support

### DIFF
--- a/extras/delta/README.md
+++ b/extras/delta/README.md
@@ -1,0 +1,19 @@
+## Usage
+
+> [!IMPORTANT]
+> The [Bat theme](../textmate/README.md###Bat) must be installed first as delta uses bat's themes for syntax highlighting.
+
+Put the following config into your `.gitconfig`
+
+The syntax theme is contained in the gitconfig and do not have to been manually declared like in [Delta Syntax-Theme](../textmate/README.md###Delta-Syntax-Theme).
+
+```gitconfig
+[include]
+ path = <config-path>/delta/themes/cyberdream.gitconfig
+ path = <config-path>/delta/themes/cyberdream-light.gitconfig
+
+[delta]
+ features = cyberdream-<dark|light>
+```
+
+See also: [Delta Custom Themes](https://dandavison.github.io/delta/custom-themes.html)

--- a/extras/delta/README.md
+++ b/extras/delta/README.md
@@ -1,11 +1,11 @@
 ## Usage
 
 > [!IMPORTANT]
-> The [Bat theme](../textmate/README.md###Bat) must be installed first as delta uses bat's themes for syntax highlighting.
+> The [Bat theme](../textmate/README.md#bat) must be installed first as delta uses bat's themes for syntax highlighting.
 
 Put the following config into your `.gitconfig`
 
-The syntax theme is contained in the gitconfig and do not have to been manually declared like in [Delta Syntax-Theme](../textmate/README.md###Delta-Syntax-Theme).
+The syntax theme is contained in the gitconfig and does not have to be manually declared like in [Delta Syntax-Theme](../textmate/README.md#delta-syntax-theme).
 
 ```gitconfig
 [include]

--- a/extras/textmate/README.md
+++ b/extras/textmate/README.md
@@ -34,7 +34,7 @@ Add the theme to the config.
 See [Bat - Adding a new theme](https://github.com/sharkdp/bat?tab=readme-ov-file#adding-new-themes)
 or [Bat - Configuration file](https://github.com/sharkdp/bat?tab=readme-ov-file#configuration-file)
 
-### Delta
+### Delta-Syntax-Theme
 
 Prerequisite [Bat](#bat) theme.
 
@@ -48,4 +48,6 @@ Add the theme to your [delta configuration section](https://dandavison.github.io
   syntax-theme = cyberdream
 ```
 
-See [delta](https://dandavison.github.io/delta/)
+See [Delta Custom Themes](https://dandavison.github.io/delta/custom-themes.html)
+
+> For delta background color theme see [extras/delta/README.md](../delta/README.md).

--- a/lua/cyberdream/extra/delta.lua
+++ b/lua/cyberdream/extra/delta.lua
@@ -1,0 +1,83 @@
+local colors = require("cyberdream.colors")
+local util = require("cyberdream.util")
+
+local M = {}
+
+--- Generate cyberdream theme for https://dandavison.github.io/delta
+--- @param variant string: Variation of the colorscheme to use.
+function M.generate(variant)
+    local template = [==[
+[delta "${name}"]
+	blame-palette = "${bg} ${palette_bg_1} ${palette_bg_2} ${palette_bg_3} ${palette_bg_4}}"
+	commit-decoration-style = "${grey}" bold box ul
+	${variant} = true
+	file-decoration-style = "${grey}"
+	file-style = "${fg}"
+	hunk-header-decoration-style = "${grey}" box ul
+	hunk-header-file-style = bold
+	hunk-header-line-number-style = bold "${lightgray}"
+	hunk-header-style = file line-number syntax
+	line-numbers-left-style = "${grey}"
+	line-numbers-minus-style = bold "${red}"
+	line-numbers-plus-style = bold "${green}"
+	line-numbers-right-style = "${grey}"
+	line-numbers-zero-style = "${grey}"
+	minus-emph-style = bold syntax "${minus_emph}"
+	minus-style = syntax "${minus}"
+	plus-emph-style = bold syntax "${plus_emph}"
+	plus-style = syntax "${plus}"
+  map-styles = \
+    bold purple => syntax "${map_style_purple}", \
+    bold blue   => syntax "${map_style_blue}", \
+    bold cyan   => syntax "${map_style_cyan}", \
+    bold yellow => syntax "${map_style_yellow}"
+  # Should match the name of the bat theme
+	syntax-theme = ${name}
+]==]
+
+    local theme = vim.fn.copy(colors[variant])
+
+    local function generate_palette(hex, steps, lightness_step, colorname)
+        local rgb = util.hex_to_rgb(hex)
+        local hsl = util.rgb_to_hsl(rgb)
+        for i = 0, steps - 1 do
+            local new_hsl = { hsl[1], hsl[2], math.min(hsl[3] + i * lightness_step, 100) }
+            local new_rgb = util.hsl_to_rgb(new_hsl)
+            local color = util.rgb_to_hex({
+                math.floor(new_rgb[1]),
+                math.floor(new_rgb[2]),
+                math.floor(new_rgb[3]),
+            })
+            theme["palette_" .. colorname .. "_" .. (i + 1)] = color
+        end
+    end
+
+    -- Add palette bg colors
+    generate_palette(theme.bg_alt, 4, variant == "default" and 10 or -10, "bg")
+
+    -- Add lightgray
+    local base_color = variant == "default" and theme.fg or theme.bg
+    theme.lightgray = util.blend(theme.grey, base_color, 0.8)
+
+    -- Add minus colors
+    theme.minus_emph = util.blend(theme.bg, theme.red, "default" and 0.6 or 0.8)
+    theme.minus = util.blend(theme.bg, theme.red, "default" and 0.8 or 0.6)
+
+    -- Add plus colors
+    theme.plus_emph = util.blend(theme.bg, theme.green, "default" and 0.6 or 0.8)
+    theme.plus = util.blend(theme.bg, theme.green, "default" and 0.8 or 0.6)
+
+    -- Add map style colors
+    theme.map_style_purple = util.blend(theme.bg, theme.purple, variant == "default" and 0.6 or 0.8)
+    theme.map_style_blue = util.blend(theme.bg, theme.blue, variant == "default" and 0.6 or 0.8)
+    theme.map_style_cyan = util.blend(theme.bg, theme.cyan, variant == "default" and 0.6 or 0.8)
+    theme.map_style_yellow = util.blend(theme.bg, theme.yellow, variant == "default" and 0.6 or 0.8)
+
+    -- Theme structure
+    theme.name = variant == "default" and "cyberdream" or "cyberdream-light"
+    theme.variant = variant == "default" and "dark" or "light"
+
+    return util.parse_extra_template(template, theme)
+end
+
+return M

--- a/lua/cyberdream/extra/delta.lua
+++ b/lua/cyberdream/extra/delta.lua
@@ -8,7 +8,7 @@ local M = {}
 function M.generate(variant)
     local template = [==[
 [delta "${name}"]
-	blame-palette = "${bg} ${palette_bg_1} ${palette_bg_2} ${palette_bg_3} ${palette_bg_4}}"
+	blame-palette = "${bg} ${palette_bg_1} ${palette_bg_2} ${palette_bg_3} ${palette_bg_4}"
 	commit-decoration-style = "${grey}" bold box ul
 	${variant} = true
 	file-decoration-style = "${grey}"
@@ -26,12 +26,12 @@ function M.generate(variant)
 	minus-style = syntax "${minus}"
 	plus-emph-style = bold syntax "${plus_emph}"
 	plus-style = syntax "${plus}"
-  map-styles = \
-    bold purple => syntax "${map_style_purple}", \
-    bold blue   => syntax "${map_style_blue}", \
-    bold cyan   => syntax "${map_style_cyan}", \
-    bold yellow => syntax "${map_style_yellow}"
-  # Should match the name of the bat theme
+	map-styles = \
+	  bold purple => syntax "${map_style_purple}", \
+	  bold blue   => syntax "${map_style_blue}", \
+	  bold cyan   => syntax "${map_style_cyan}", \
+	  bold yellow => syntax "${map_style_yellow}"
+	# Should match the name of the bat theme
 	syntax-theme = ${name}
 ]==]
 
@@ -60,12 +60,12 @@ function M.generate(variant)
     theme.lightgray = util.blend(theme.grey, base_color, 0.8)
 
     -- Add minus colors
-    theme.minus_emph = util.blend(theme.bg, theme.red, "default" and 0.6 or 0.8)
-    theme.minus = util.blend(theme.bg, theme.red, "default" and 0.8 or 0.6)
+    theme.minus_emph = util.blend(theme.bg, theme.red, variant == "default" and 0.6 or 0.8)
+    theme.minus = util.blend(theme.bg, theme.red, variant == "default" and 0.8 or 0.6)
 
     -- Add plus colors
-    theme.plus_emph = util.blend(theme.bg, theme.green, "default" and 0.6 or 0.8)
-    theme.plus = util.blend(theme.bg, theme.green, "default" and 0.8 or 0.6)
+    theme.plus_emph = util.blend(theme.bg, theme.green, variant == "default" and 0.6 or 0.8)
+    theme.plus = util.blend(theme.bg, theme.green, variant == "default" and 0.8 or 0.6)
 
     -- Add map style colors
     theme.map_style_purple = util.blend(theme.bg, theme.purple, variant == "default" and 0.6 or 0.8)

--- a/lua/cyberdream/extra/init.lua
+++ b/lua/cyberdream/extra/init.lua
@@ -8,6 +8,7 @@ M.variants = {
 M.extras = {
     alacritty = { extension = "toml", name = "alacritty" },
     base16 = { extension = "yaml", name = "base16" },
+    delta = { extension = "gitconfig", name = "delta" },
     fish = { extension = "theme", name = "fish" },
     foot = { extension = "ini", name = "foot" },
     ghostty = { extension = nil, name = "ghostty" },


### PR DESCRIPTION
Hi Scott, maybe I can convince you with some screenshots 😉.

Git diff with delta and just the Cyberdream syntax theme:
<img width="355" height="905" alt="bat_syntax_only" src="https://github.com/user-attachments/assets/d3367438-0d76-4fdb-89b6-f8a2e3545e08" />

Git diff with delta, Cyberdream syntax, and delta theme (notice the Cyberdream-based background colors):
<img width="355" height="905" alt="delta_theme" src="https://github.com/user-attachments/assets/1d6ed61f-080e-4529-bb88-1a56cddf3251" />

Regards.