### PR TITLE
fix(extensions): correct DiagnosticVirtualTextError

### DIFF
--- a/lua/cyberdream/extensions/base.lua
+++ b/lua/cyberdream/extensions/base.lua
@@ -132,7 +132,7 @@ function M.get(opts, t)
         DiagnosticHint = { fg = t.cyan },
         DiagnosticUnnecessary = { fg = t.grey },
 
-        DiagnosiiucVirtualTextError = { fg = t.red },
+        DiagnosticVirtualTextError = { fg = t.red },
         DiagnosticVirtualTextWarn = { fg = t.yellow },
         DiagnosticVirtualTextInfo = { fg = t.blue },
         DiagnosticVirtualTextHint = { fg = t.cyan },


### PR DESCRIPTION
Corrected a typo in `lua/cyberdream/extensions/base.lua`