### PR TITLE
feat(extras): init vim colorscheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ We've cooked up some wonderful extras to enhance your cyberdream experience. Mos
 - **[Tilix](extras/tilix/)**
 - **[Tmux](extras/tmux/)**
 - **[Vicinae](extras/vicinae/)**
+- **[Vim](extras/vim/)**
 - **[Vivid](extras/vivid/)**
 - **[Warp](extras/warp/)**
 - **[Wezterm](extras/wezterm/)**

--- a/extras/vim/README.md
+++ b/extras/vim/README.md
@@ -1,0 +1,8 @@
+### Usage 
+#### Install
+1. Place the `cyberdream.vim` under `$HOME/.vim/colors/`
+2. Open `vim`  and run the command `:colorscheme cyberdream`
+3. If you want permanently to use the theme, add this to your `$HOME/.vimrc`
+```
+colorscheme cyberdream
+```

--- a/extras/vim/README.md
+++ b/extras/vim/README.md
@@ -1,8 +1,8 @@
-### Usage 
-#### Install
+## Usage 
+### Install
 1. Place the `cyberdream.vim` under `$HOME/.vim/colors/`
 2. Open `vim`  and run the command `:colorscheme cyberdream`
 3. If you want permanently to use the theme, add this to your `$HOME/.vimrc`
-```
+```vim
 colorscheme cyberdream
 ```

--- a/extras/vim/README.md
+++ b/extras/vim/README.md
@@ -1,8 +1,11 @@
-## Usage 
+## Usage
+
 ### Install
+
 1. Place the `cyberdream.vim` under `$HOME/.vim/colors/`
-2. Open `vim`  and run the command `:colorscheme cyberdream`
+2. Open `vim` and run the command `:colorscheme cyberdream`
 3. If you want permanently to use the theme, add this to your `$HOME/.vimrc`
+
 ```vim
 colorscheme cyberdream
 ```

--- a/extras/vim/cyberdream-light.vim
+++ b/extras/vim/cyberdream-light.vim
@@ -1,0 +1,28 @@
+" cyberdream-light.vim - Cyberdream theme for VIM.
+" Maintainer: 0l3d
+" Description: Cyberdream theme for VIM.
+
+highlight clear
+
+if exists("syntax_on")
+  syntax reset
+endif
+
+let g:colors_name = "cyberdream-light"
+set termguicolors
+
+highlight Normal guibg=#ffffff guifg=#16181a
+highlight CursorLine guibg=#eaeaea
+highlight Visual guibg=#acacac
+
+highlight Comment guifg=#7b8496
+highlight Identifier guifg=#0057d1
+highlight String guifg=#008b0c
+highlight Constant guifg=#008c99
+highlight Error guifg=#d11500
+highlight Todo guifg=#997b00
+highlight Statement guifg=#d100bf
+highlight Type guifg=#f40064
+highlight Number guifg=#d17c00
+highlight Function guifg=#a018ff
+

--- a/extras/vim/cyberdream.vim
+++ b/extras/vim/cyberdream.vim
@@ -1,0 +1,27 @@
+" cyberdream.vim - Cyberdream theme for VIM.
+" Maintainer: 0l3d
+" Description: Cyberdream theme for VIM.
+
+highlight clear
+
+if exists("syntax_on")
+  syntax reset
+endif
+
+let g:colors_name = "cyberdream"
+set termguicolors
+
+highlight Normal guibg=#16181a guifg=#ffffff
+highlight CursorLine guibg=#1e2124
+highlight Visual guibg=#3c4048
+
+highlight Comment guifg=#7b8496
+highlight Identifier guifg=#5ea1ff
+highlight String guifg=#5eff6c
+highlight Constant guifg=#5effff
+highlight Error guifg=#ff6e5e
+highlight Todo guifg=#f1ff5e
+highlight Statement guifg=#ff5ef1
+highlight Type guifg=#ff5ea0
+highlight Number guifg=#ffbd5e
+highlight Function guifg=#bd5eff

--- a/lua/cyberdream/extra/init.lua
+++ b/lua/cyberdream/extra/init.lua
@@ -30,6 +30,7 @@ M.extras = {
     tilix = { extension = "json", name = "tilix" },
     tmux = { extension = "conf", name = "tmux" },
     vicinae = { extension = "toml", name = "vicinae" },
+    vim = { extension = "vim", name = "vim" },
     vivid = { extension = "yml", name = "vivid" },
     warp = { extension = "yaml", name = "warp" },
     wezterm = { extension = "lua", name = "wezterm" },

--- a/lua/cyberdream/extra/vim.lua
+++ b/lua/cyberdream/extra/vim.lua
@@ -8,6 +8,9 @@ local M = {}
 function M.generate(variant)
     local template = [==[
 " cyberdream.vim - Cyberdream theme for VIM.
+" Maintainer: 0l3d
+" Description: Cyberdream theme for VIM.
+
 highlight clear
 
 if exists("syntax_on")
@@ -37,4 +40,3 @@ highlight Function guifg=${purple}
 end
 
 return M
-

--- a/lua/cyberdream/extra/vim.lua
+++ b/lua/cyberdream/extra/vim.lua
@@ -1,0 +1,40 @@
+local colors = require("cyberdream.colors")
+local util = require("cyberdream.util")
+
+local M = {}
+
+--- Generate cyberdream theme for vim.
+--- @param variant string: Variation of the colorscheme to use.
+function M.generate(variant)
+    local template = [==[
+" cyberdream.vim - Cyberdream theme for VIM.
+highlight clear
+
+if exists("syntax_on")
+  syntax reset
+endif
+
+let g:colors_name = "cyberdream"
+set termguicolors
+
+highlight Normal guibg=${bg} guifg=${fg}
+highlight CursorLine guibg=${bg_alt}
+highlight Visual guibg=${bg_highlight}
+
+highlight Comment guifg=${grey} gui=italic
+highlight Identifier guifg=${blue}
+highlight String guifg=${green}
+highlight Constant guifg=${cyan}
+highlight Error guifg=${red} gui=bold
+highlight Todo guifg=${yellow} gui=bold
+highlight Statement guifg=${magenta}
+highlight Type guifg=${pink}
+highlight Number guifg=${orange}
+highlight Function guifg=${purple}
+]==]
+
+    return util.parse_extra_template(template, colors[variant])
+end
+
+return M
+


### PR DESCRIPTION
I apologize for forgetting to use "feat(extras)" in my commit message and writing only "feat:" instead. About a year ago, I tried this theme in Helix and it immediately felt nostalgic to me. I enjoyed using it so much that I was disappointed it wasn't available in Vim. When I later switched back to Vim, I couldn't find the theme anymore, and since I've only been coding intermittently over the past year, I never spent much time searching for alternatives. Recently, I decided to add it myself, and I thought others might enjoy it as well, so I'd like to contribute this Vim port. I hope you'll forgive my commit naming mistake and consider the contribution.

Also, please feel free to remove the comments at the beginning of the files if you prefer, I only added them casually and they are not important to the implementation.